### PR TITLE
Fix error in "#include virtual" with absolute path

### DIFF
--- a/browsersync-ssi.js
+++ b/browsersync-ssi.js
@@ -9,12 +9,13 @@ module.exports = function browserSyncSSI(opt) {
   var opt = opt || {};
   var ext = opt.ext || '.shtml';
   var baseDir = opt.baseDir || __dirname;
+  var matcher = '/**/*' + ext;
   var version = opt.version || '1.4.0';
 
   var bsURL = version >= '1.4.0' ? '/browser-sync/browser-sync-client' : '/browser-sync-client';
   bsURL += version + '.js';
 
-  var parser = new ssi(__dirname, baseDir, baseDir);
+  var parser = new ssi(baseDir, baseDir, matcher);
 
   return function(req, res, next) {
 


### PR DESCRIPTION
Support ssi-include using absolute path. e.g. `<!--#include virtual="/inc/partial.html" -->`

It is equivalent to this commit in connect-ssi.
https://github.com/soenkekluth/connect-ssi/commit/f9d1b9f490ba586dc06910ba2781271b8ebbf920

Thanks.
