### PR TITLE
Support sub-directory without file name

### DIFF
--- a/browsersync-ssi.js
+++ b/browsersync-ssi.js
@@ -5,6 +5,7 @@ module.exports = function browserSyncSSI(opt) {
   var ssi = require('ssi');
   var path = require('path');
   var fs = require('fs');
+  var url = require('url');
 
   var opt = opt || {};
   var ext = opt.ext || '.shtml';
@@ -19,10 +20,10 @@ module.exports = function browserSyncSSI(opt) {
 
   return function(req, res, next) {
 
-    var url = req.url === '/' ? ('/index' + ext) : req.url;
-    var filename = baseDir + url.split('?')[0];
+    var pathname = url.parse(req.originalUrl || req.url).pathname;
+    var filename = path.join(baseDir, pathname.substr(-1) === '/' ? pathname + 'index' + ext : pathname);
 
-    if (url.indexOf(ext) > -1 && fs.existsSync(filename)) {
+    if (filename.indexOf(ext) > -1 && fs.existsSync(filename)) {
 
       var contents = parser.parse(filename, fs.readFileSync(filename, {
         encoding: 'utf8'


### PR DESCRIPTION
Hi. I added the supported URL.

Currently  `http://localhost:3000/` works fine,
but sub-directory, such as `http://localhost:3000/foo/` or `http://localhost:3000/foo/?params` isn't supported.
I fixed this issue.

And I have another improvement related to the "browser-sync-client.js".
I will send one more PR later.
