### PR TITLE
Improve the URL of "browser-sync-client.js"

### DIFF
--- a/browsersync-ssi.js
+++ b/browsersync-ssi.js
@@ -10,10 +10,20 @@ module.exports = function browserSyncSSI(opt) {
   var ext = opt.ext || '.shtml';
   var baseDir = opt.baseDir || __dirname;
   var matcher = '/**/*' + ext;
-  var version = opt.version || '1.4.0';
+  var version = opt.version || '';
+  var bsURL;
 
-  var bsURL = version >= '1.4.0' ? '/browser-sync/browser-sync-client.' : '/browser-sync-client.';
-  bsURL += version + '.js';
+  if (version === '') {
+    bsURL = '/browser-sync/browser-sync-client.js';
+  }
+  else {
+      if (version >= '1.4.0') {
+        bsURL = '/browser-sync/browser-sync-client.' + version + '.js';
+      }
+      else {
+        bsURL = '/browser-sync-client.' + version + '.js';
+      }
+  }
 
   var parser = new ssi(baseDir, baseDir, matcher);
 


### PR DESCRIPTION
I updated 2 points.

**1. Correct the script URL**

```
# wrong
<script async src="///browser-sync/browser-sync-client1.4.0.js "></script>

# correct
<script async src="/browser-sync/browser-sync-client.1.4.0.js"></script>
```

**2. Make "version" parameter optional**

The version number of "browser-sync-client.js" is not necessary in v0.7.0 or later. 
See: https://github.com/shakyShane/browser-sync/issues/82

When user specifies `version`, works as before. But it's optional.
I think this is more user-friendly.

```
# specify { version: '1.4.0' }
<script async src="/browser-sync/browser-sync-client.1.4.0.js"></script>

# omit version option
<script async src="/browser-sync/browser-sync-client.js"></script>
```
